### PR TITLE
add support for Space-Explorations's deep-space transport belt

### DIFF
--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -316,10 +316,8 @@ local function create_inserters(prefix, next_prefix, base_underground_name, tint
     next_upgrade = next_upgrade,
   }
 
-  if prefix == "space-" then
-    loader_inserter.collision_mask = {"floor-layer", "item-layer", "object-layer", "water-tile"}
-  end
-  if prefix == "deep-space-" then
+  --Space Exploration
+  if (prefix == "space-") or (prefix == "deep-space-") then
     loader_inserter.collision_mask = {"floor-layer", "item-layer", "object-layer", "water-tile"}
   end
 

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -319,6 +319,9 @@ local function create_inserters(prefix, next_prefix, base_underground_name, tint
   if prefix == "space-" then
     loader_inserter.collision_mask = {"floor-layer", "item-layer", "object-layer", "water-tile"}
   end
+  if prefix == "deep-space-" then
+    loader_inserter.collision_mask = {"floor-layer", "item-layer", "object-layer", "water-tile"}
+  end
 
   if settings.startup["miniloader-energy-usage"].value then
     loader_inserter.energy_per_movement = "2kJ"

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -164,6 +164,12 @@ local ingredient_sets = {
       {"stack-inserter", 4},
     },
   },
+  ["deep-space-miniloader"] = {
+    {
+      {"se-deep-space-underground-belt-black", 1},
+      {"stack-inserter", 6},
+    },
+  },
 
   -- Random Factorio Things
   ["nuclear-miniloader"] = {

--- a/prototypes/templates.lua
+++ b/prototypes/templates.lua
@@ -154,4 +154,13 @@ if data.raw.item["se-space-transport-belt"] then
   }
 end
 
+if data.raw.item["se-deep-space-transport-belt-black"] then
+  templates["deep-space-"] = {
+    prerequisite_techs = {"se-deep-space-transport-belt"},
+    tint = {r=0,g=0,b=0},
+    base_underground_name = "se-deep-space-underground-belt-black",
+  }
+  templates["space-"]["next_prefix"] = "deep-space-"
+end
+
 return templates


### PR DESCRIPTION
Hi, 
I have added support for Space-Explorations's deep-space transport belt to the mod. 
- black variant of deep-space transport belt only
- No localization's included
- I have done superficial testing and Factorio + SE starts. The Loader can be crafted and can be placed in space
- please check anyways if I have missed something when adding the new loader
- slightly unsure about that "next prefix" in templates.lua

Please evaluate if my additions make sense.

Thank you and have a nice day :-)