### PR TITLE
Improve color matching for RandomFactorioThings

### DIFF
--- a/prototypes/templates.lua
+++ b/prototypes/templates.lua
@@ -84,12 +84,12 @@ end
 if mods["RandomFactorioThings"] then
   templates["nuclear-"] = {
     prerequisite_techs = {"nuclear-logistics", "express-miniloader"},
-    tint = {r=0, g=1, b=0}
+    tint = util.color("00ff00")
   }
   if mods["PlutoniumEnergy"] then
     templates["plutonium-"] = {
       prerequisite_techs = {"plutonium-logistics", "nuclear-miniloader"},
-      tint = {r=0.1,g=0.9,b=0.7}
+      tint = util.color("00e1ffde")
     }
   end
 end


### PR DESCRIPTION
I have some improved techniques for making masks so I will probably come through and update the mask sprites at some point, which will allow an even closer color match (initial experiments are promising). 

In the mean time, this color is a better match than what was there:
_Before_
![image](https://user-images.githubusercontent.com/35714562/108428130-f74d6180-71f2-11eb-9a59-c9a7bed9e8b9.png)

_After_
![image](https://user-images.githubusercontent.com/35714562/108427894-ac334e80-71f2-11eb-9751-76aacb847eda.png)
