### PR TITLE
Make filter settings independent of entity order

### DIFF
--- a/circuit.lua
+++ b/circuit.lua
@@ -30,26 +30,6 @@ local function copy_inserter_filters(source_inserter, dest_inserter, filters)
   end
 end
 
-function M.sync_filters(entity)
-  local inserters = util.get_loader_inserters(entity)
-  local source_inserter = inserters[1]
-
-  if #inserters < 2 then return end
-
-  if not util.is_output_miniloader_inserter(entity)
-  or not global.split_lane_configuration[source_inserter.unit_number] then
-    -- sync left and right lanes
-    copy_inserter_filters(entity, inserters[2])
-  end
-  for i = 1, #inserters, 2 do
-    copy_inserter_filters(source_inserter, inserters[i])
-  end
-  source_inserter = inserters[2]
-  for i = 4, #inserters, 2 do
-    copy_inserter_filters(source_inserter, inserters[i])
-  end
-end
-
 local function copy_inserter_behavior(source_inserter, target)
   local source_behavior = source_inserter.get_or_create_control_behavior()
   local behavior = target.get_or_create_control_behavior()
@@ -80,7 +60,7 @@ function M.sync_behavior(inserter)
 
   local source_inserter = inserters[1]
   if not util.is_output_miniloader_inserter(source_inserter)
-  or not global.split_lane_configuration[source_inserter.unit_number] then
+  or not util.get_split_configuration(source_inserter) then
     -- sync left and right lanes
     copy_inserter_behavior(source_inserter, inserters[2])
   end

--- a/control.lua
+++ b/control.lua
@@ -280,6 +280,7 @@ local function on_placed_blueprint(ev, player, bp_entities)
   for _, bp_entity in pairs(bp_entities) do
     if util.is_miniloader_inserter_name(bp_entity.name) then
       blueprint_contained_miniloader = true
+      if not global.placed_blueprint_tags then global.placed_blueprint_tags = {} end
       if bp_entity.tags ~= nil then
         local relative_position = util.moveposition(bp_entity.position, from_center)
         if ev.flip_horizontal then
@@ -290,7 +291,6 @@ local function on_placed_blueprint(ev, player, bp_entities)
         end
         relative_position = util.rotate_position(relative_position, ev.direction)
         local build_position = util.moveposition(relative_position, place_position)
-        if not global.placed_blueprint_tags then global.placed_blueprint_tags = {} end
         position_str = build_position.x.."p"..build_position.y
         global.placed_blueprint_tags[position_str] = bp_entity.tags
       elseif global.debug and bp_entity.filter_slot_count then

--- a/control.lua
+++ b/control.lua
@@ -166,12 +166,12 @@ local function on_rotated(ev)
       force = entity.force,
     }[1]
     local filter_settings = util.get_loader_filter_settings(miniloader)
-    filter_settings.split = false
+    if filter_settings ~= nil then filter_settings.split = false end
     miniloader.rotate{ by_player = game.players[ev.player_index] }
     util.update_inserters(miniloader, filter_settings)
   elseif util.is_miniloader(entity) then
     local filter_settings = util.get_loader_filter_settings(entity)
-    filter_settings.split = false
+    if filter_settings ~= nil then filter_settings.split = false end
     util.update_inserters(entity, filter_settings)
   elseif use_snapping then
     snapping.check_for_loaders(ev)

--- a/control.lua
+++ b/control.lua
@@ -58,6 +58,7 @@ end
 -- Event Handlers
 
 local function on_init()
+  global.debug = true
   global.player_placed_blueprint = {}
   global.previous_opened_blueprint_for = {}
   global.split_lane_configuration = {}
@@ -218,14 +219,14 @@ local function on_miniloader_inserter_mined(ev)
 
   local inserters = util.get_loader_inserters(entity)
   if util.is_output_miniloader_inserter(entity)
-  and global.split_lane_configuration[entity.unit_number] then
+  and util.get_split_configuration(entity) then
     fast_replace_miniloader_state = {
       position = entity.position,
       right_lane_settings = util.capture_settings(inserters[2]),
       surface = entity.surface,
       tick = ev.tick,
     }
-    global.split_lane_configuration[entity.unit_number] = nil
+    util.set_split_configuration(entity, nil)
   end
   for i=1,#inserters do
     if inserters[i] ~= entity then
@@ -344,12 +345,13 @@ local function on_entity_settings_pasted(ev)
       local right_src = util.get_loader_inserters(src)[2]
       local right_dst = util.get_loader_inserters(dst)[2]
       if right_src and right_dst then
-        global.split_lane_configuration[dst.unit_number] = global.split_lane_configuration[src.unit_number]
+        util.set_split_configuration(dst, util.get_split_configuration(src))
         circuit.copy_inserter_settings(right_src, right_dst)
+        util.propagate_filters(right_dst)
       end
     end
     circuit.sync_behavior(dst)
-    circuit.sync_filters(dst)
+    util.propagate_filters(dst)
   end
 end
 

--- a/lualib/blueprint.lua
+++ b/lualib/blueprint.lua
@@ -180,6 +180,30 @@ function M.filter_miniloaders(bp, surface)
         end
         left_inserter = overlapping[1]
       end
+      if left_inserter ~= overlapping[1]
+      and overlapping[1].connections ~= nill
+      and next(overlapping[1].connections) then
+        -- FIXME: This depends on the first inserter having the external
+        -- circuit connections
+        local ext_connections = overlapping[1].connections
+        overlapping[1].connections = left_inserter.connections
+        left_inserter.connections = ext_connections
+        for _, bp_entity in ipairs(bp_entities) do
+          if bp_entity.connections ~= nil then
+            for _, wires in pairs(bp_entity.connections) do
+              for wire_type, wire_connections in pairs(wires) do
+                for _, connection in ipairs(wire_connections) do
+                  if connection.entity_id == overlapping[1].entity_number then
+                    connection.entity_id = left_inserter.entity_number
+                  elseif connection.entity_id == left_inserter.entity_number then
+                    connection.entity_id = overlapping[1].entity_number
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
       tag_with_configuration(surface, left_inserter)
       find_slaves(overlapping, left_inserter, to_remove)
       -- FIXME: Is there any guarantee that same position entities will be consecutive?

--- a/lualib/miniloader.lua
+++ b/lualib/miniloader.lua
@@ -144,18 +144,21 @@ local function fixup(main_inserter, orientation, tags)
     end
   end
   local loader = ensure_loader(main_inserter, orientation)
+  local filter_settings = util.get_loader_filter_settings(loader)
+  if tags and tags.right_lane_settings then
+    filter_settings.filters.right = tags.right_lane_settings.filters
+  end
   local inserters = ensure_inserters(util.num_inserters(loader), main_inserter)
   circuit.copy_inserter_settings(main_inserter, inserters[1])
   ensure_chest(main_inserter)
 
   util.update_inserters(loader)
-  util.update_filters(loader)
+  util.update_filters(loader, filter_settings)
   if tags and tags.right_lane_settings then
-    global.split_lane_configuration[inserters[1].unit_number] = true
+    util.set_split_configuration(inserters[1], true)
     util.apply_settings(tags.right_lane_settings, inserters[2])
   end
   circuit.sync_behavior(main_inserter)
-  circuit.sync_filters(main_inserter)
   circuit.sync_partner_connections(main_inserter)
 
   return loader

--- a/lualib/miniloader.lua
+++ b/lualib/miniloader.lua
@@ -149,6 +149,7 @@ local function fixup(main_inserter, orientation, tags)
   ensure_chest(main_inserter)
 
   util.update_inserters(loader)
+  util.update_filters(loader)
   if tags and tags.right_lane_settings then
     global.split_lane_configuration[inserters[1].unit_number] = true
     util.apply_settings(tags.right_lane_settings, inserters[2])

--- a/lualib/miniloader.lua
+++ b/lualib/miniloader.lua
@@ -144,18 +144,29 @@ local function fixup(main_inserter, orientation, tags)
     end
   end
   local loader = ensure_loader(main_inserter, orientation)
-  local filter_settings = util.get_loader_filter_settings(loader)
-  if tags and tags.right_lane_settings then
-    filter_settings.filters.right = tags.right_lane_settings.filters
+  local filter_settings = nil
+  if tags then
+    if tags.filter_settings then
+      filter_settings = tags.filter_settings
+    elseif tags.right_lane_settings then
+      filter_settings = util.get_loader_filter_settings(loader)
+      if filter_settings then
+        game.print("Using miniloader filter settings from legacy tag")
+        filter_settings.filters.right = tags.right_lane_settings.filters
+      end
+    end
+  else
+    filter_settings = util.get_loader_filter_settings(loader)
+    if global.debug and main_inserter.filter_slot_count > 0 then
+      game.print("fixup without tags found filter settings:\n".. serpent.line(filter_settings))
+    end
   end
   local inserters = ensure_inserters(util.num_inserters(loader), main_inserter)
   circuit.copy_inserter_settings(main_inserter, inserters[1])
   ensure_chest(main_inserter)
 
-  util.update_inserters(loader)
-  util.update_filters(loader, filter_settings)
+  util.update_inserters(loader, filter_settings)
   if tags and tags.right_lane_settings then
-    util.set_split_configuration(inserters[1], true)
     util.apply_settings(tags.right_lane_settings, inserters[2])
   end
   circuit.sync_behavior(main_inserter)


### PR DESCRIPTION
This seems to be the cause in many cases, if not the only cause, for split belt filter miniloaders to lose the settings.

I'm not sure order of inserters coming from `find_entities_filtered` (and so `util.get_loader_inserters`) is really defined to be stable in any way, But it does seem to be fairly stable so if `fixup` is actually getting called in all cases that it changes then adding this should actually fix the problem completely.

One note is that the changes that `util.update_inserters` makes frequently (always?) causes the inserter order from `find_entities_filtered` to change, so the filter update has to be done after that call.